### PR TITLE
Handle relative paths and shorthand includes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
 			"name": "Launch Client",
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
-			"outFiles": ["${workspaceRoot}/client/out/**/*.js"],
+			"outFiles": ["${workspaceRoot}/client/dist/**/*.js"],
 			"preLaunchTask": {
 				"type": "npm",
 				"script": "watch"
@@ -20,7 +20,7 @@
 			"name": "Attach to Server",
 			"port": 6009,
 			"restart": true,
-			"outFiles": ["${workspaceRoot}/server/out/**/*.js"]
+			"outFiles": ["${workspaceRoot}/server/dist/**/*.js"]
 		},
 		{
 			"name": "Language Server E2E Test",
@@ -32,7 +32,7 @@
 				"--extensionTestsPath=${workspaceRoot}/client/out/test",
 				"${workspaceRoot}/client/testFixture"
 			],
-			"outFiles": ["${workspaceRoot}/client/out/test/**/*.js"]
+			"outFiles": ["${workspaceRoot}/client/dist/test/**/*.js"]
 		}
 	],
 	"compounds": [

--- a/client/src/language/documentLink.ts
+++ b/client/src/language/documentLink.ts
@@ -9,21 +9,40 @@ export class DocumentLinkProvider implements DocumentLinkProvider {
 		const linkPattern: RegExp = /(?<=file=['"]).*\.tpl/g;
 
 		for (let match: RegExpExecArray; match = linkPattern.exec(text); match) {
+
+			// Get position in document
+			const range = new Range(
+				document.positionAt(match.index),
+				document.positionAt(match.index + match[0].length)
+			);
+
+			// Get target file path
+			const fPath = match[0];
+
+			// Current file directory path
+			const docdir = path.dirname(document.uri.path);
+
+			// Handle relative paths
+			if (fPath.startsWith('./')) {
+				const absPath = path.posix.resolve(docdir, fPath);
+
+				results.push(
+					new DocumentLink(range, Uri.parse(absPath))
+				);
+
+				continue;
+			}
+
 			const uri = path.posix.normalize(match[0]?.replace(/^[/]?/, '/'));
 
 			const targets = await workspace.findFiles('**' + uri, null, 1);
 
 			// To create file if path not found
 			if (!targets.length) {
-				const docdir = path.dirname(document.uri.path);
 				const pathresolved = path.posix.resolve(docdir, match[0]?.replace(/^[/]?/, ''));
 				targets.push(Uri.parse(pathresolved));
 			}
 
-			const range = new Range(
-				document.positionAt(match.index),
-				document.positionAt(match.index + match[0].length)
-			);
 			const doumentlink = new DocumentLink(range, targets[0]);
 
 			results.push(doumentlink);

--- a/client/src/language/documentLink.ts
+++ b/client/src/language/documentLink.ts
@@ -6,7 +6,7 @@ export class DocumentLinkProvider implements DocumentLinkProvider {
 	async provideDocumentLinks(document: TextDocument, token: CancellationToken) {
 		const results: DocumentLink[] = [];
 		const text: string = document.getText();
-		const linkPattern: RegExp = /(?<=file=['"]).*\.tpl/g;
+		const linkPattern: RegExp = /(?<=['"]).*\.tpl(?=['"])/g;
 
 		for (let match: RegExpExecArray; match = linkPattern.exec(text); match) {
 

--- a/extension.webpack.config.js
+++ b/extension.webpack.config.js
@@ -13,7 +13,8 @@ const path = require('path');
 const browserClientConfig = {
 	context: path.join(__dirname, 'client'),
 	mode: 'none',
-	target: 'node', // vscode extensions run in a node context	
+	devtool: 'nosources-source-map',
+	target: 'node', // vscode extensions run in a node context
 	entry: {
 		nodeClientMain: './src/extension.ts',
 	},
@@ -21,6 +22,7 @@ const browserClientConfig = {
 		filename: '[name].js',
 		path: path.join(__dirname, 'client', 'dist', 'node'),
 		libraryTarget: 'commonjs',
+		devtoolModuleFilenameTemplate: '[absolute-resource-path]'
 	},
 	resolve: {
 		extensions: ['.ts', '.js'], // support ts-files and js-files
@@ -47,7 +49,7 @@ const browserClientConfig = {
 const browserServerConfig = {
 	context: path.join(__dirname, 'server'),
 	mode: 'none',
-	target: 'node', // vscode extensions run in a node context	
+	target: 'node', // vscode extensions run in a node context
 	entry: {
 		nodeServerMain: './src/node/htmlServerMain.ts',
 	},


### PR DESCRIPTION
This PR resolves (:wink:) issues with relative filenames (`{include file="./list.tpl"}`) in big repos where multiple files can have a similar path (`findFiles` would return many results and the first one would be picked).

Also handles shorthand includes (without the "path=" argument).

Any feedback is appreciated!

PS: Ignore the "Fix debugging" commit, if needed.